### PR TITLE
feat: implement burner wallet for development testing

### DIFF
--- a/packages/nextjs/components/BurnerWalletInfo.tsx
+++ b/packages/nextjs/components/BurnerWalletInfo.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import { getBurnerPrivateKey, deleteBurnerWallet } from "~~/services/web3/burnerWallet";
+
+/**
+ * BurnerWalletInfo Component
+ *
+ * Displays information and controls for the burner wallet in development mode.
+ * Shows warnings, allows exporting private key, and deleting the burner wallet.
+ */
+export const BurnerWalletInfo = () => {
+  const { connector, address } = useAccount();
+  const [privateKey, setPrivateKey] = useState<string>("");
+  const [showPrivateKey, setShowPrivateKey] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // Only show if connected with burner wallet
+    if (connector?.id === "burner") {
+      const pk = getBurnerPrivateKey();
+      setPrivateKey(pk || "");
+    } else {
+      setPrivateKey("");
+      setShowPrivateKey(false);
+    }
+  }, [connector]);
+
+  // Don't render if not using burner wallet
+  if (connector?.id !== "burner" || !address) {
+    return null;
+  }
+
+  const handleCopyPrivateKey = async () => {
+    if (privateKey) {
+      await navigator.clipboard.writeText(privateKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDeleteBurner = () => {
+    if (confirm("⚠️ This will delete your burner wallet permanently. Any funds will be lost. Continue?")) {
+      deleteBurnerWallet();
+      // Reload page to disconnect
+      window.location.reload();
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 max-w-sm z-50">
+      <div className="alert alert-warning shadow-lg">
+        <div className="flex flex-col gap-2 w-full">
+          {/* Warning Header */}
+          <div className="flex items-start gap-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="stroke-current flex-shrink-0 h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <div className="flex-1">
+              <h3 className="font-bold text-sm">⚠️ Burner Wallet (Development Only)</h3>
+              <p className="text-xs mt-1">
+                DO NOT send real funds! Private key stored in browser localStorage.
+              </p>
+            </div>
+          </div>
+
+          {/* Address Display */}
+          <div className="text-xs font-mono bg-base-200 p-2 rounded">
+            <span className="opacity-60">Address:</span> {address.slice(0, 6)}...{address.slice(-4)}
+          </div>
+
+          {/* Private Key Section */}
+          <div className="flex flex-col gap-2">
+            <button
+              className="btn btn-xs btn-outline"
+              onClick={() => setShowPrivateKey(!showPrivateKey)}
+            >
+              {showPrivateKey ? "Hide" : "Show"} Private Key
+            </button>
+
+            {showPrivateKey && privateKey && (
+              <div className="flex flex-col gap-2">
+                <div className="text-xs font-mono bg-error bg-opacity-10 p-2 rounded break-all border border-error">
+                  {privateKey}
+                </div>
+                <button className="btn btn-xs btn-primary" onClick={handleCopyPrivateKey}>
+                  {copied ? "✓ Copied!" : "Copy Private Key"}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-2 mt-2">
+            <button className="btn btn-xs btn-error flex-1" onClick={handleDeleteBurner}>
+              Delete Burner
+            </button>
+          </div>
+
+          {/* Info */}
+          <div className="text-xs opacity-70 border-t border-warning pt-2">
+            <p>💡 Burner wallets are temporary test wallets.</p>
+            <p>🔒 For production, use MetaMask or WalletConnect.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar";
 import { Toaster } from "react-hot-toast";
 import { WagmiProvider } from "wagmi";
+import { BurnerWalletInfo } from "~~/components/BurnerWalletInfo";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
@@ -20,6 +21,7 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
         <Footer />
       </div>
       <Toaster />
+      <BurnerWalletInfo />
     </>
   );
 };

--- a/packages/nextjs/public/burner-icon.svg
+++ b/packages/nextjs/public/burner-icon.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Flame icon for burner wallet -->
+  <path d="M12 2C12 2 8 6 8 10C8 12.2091 9.79086 14 12 14C14.2091 14 16 12.2091 16 10C16 6 12 2 12 2Z" fill="#FF4500" stroke="#FF4500" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 14C12 14 10 16 10 18C10 19.1046 10.8954 20 12 20C13.1046 20 14 19.1046 14 18C14 16 12 14 12 14Z" fill="#FFA500" stroke="#FFA500" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="12" cy="10" r="1.5" fill="#FFD700"/>
+</svg>

--- a/packages/nextjs/services/web3/burnerWallet.ts
+++ b/packages/nextjs/services/web3/burnerWallet.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { createConnector } from "wagmi";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import type { Address } from "viem";
+
+// Storage key for burner wallet private key
+const BURNER_STORAGE_KEY = "susuchain.burner.pk";
+
+/**
+ * Custom Burner Wallet Connector for Development
+ *
+ * ⚠️ WARNING: For development and testing only!
+ * - Private keys stored in localStorage (NOT SECURE)
+ * - Do NOT send real funds to burner addresses
+ * - Keys are lost when localStorage is cleared
+ */
+export function burnerWalletConnector() {
+  return createConnector((config) => {
+    let currentAccount: ReturnType<typeof privateKeyToAccount> | null = null;
+
+    return {
+      id: "burner",
+      name: "Burner Wallet",
+      type: "injected" as const,
+
+      async setup() {
+        // Load existing burner wallet if available
+        if (typeof window !== "undefined") {
+          const existingPk = localStorage.getItem(BURNER_STORAGE_KEY);
+          if (existingPk) {
+            try {
+              currentAccount = privateKeyToAccount(existingPk as `0x${string}`);
+            } catch (error) {
+              // Invalid private key, will create new one on connect
+              console.warn("Invalid burner key in storage, will create new one");
+              localStorage.removeItem(BURNER_STORAGE_KEY);
+            }
+          }
+        }
+      },
+
+      async connect() {
+        if (typeof window === "undefined") {
+          throw new Error("Burner wallet only works in browser environment");
+        }
+
+        // Create new burner if doesn't exist
+        if (!currentAccount) {
+          const privateKey = generatePrivateKey();
+          currentAccount = privateKeyToAccount(privateKey);
+          localStorage.setItem(BURNER_STORAGE_KEY, privateKey);
+        }
+
+        return {
+          accounts: [currentAccount.address as Address],
+          chainId: config.chains[0].id,
+        };
+      },
+
+      async disconnect() {
+        if (typeof window !== "undefined") {
+          localStorage.removeItem(BURNER_STORAGE_KEY);
+          currentAccount = null;
+        }
+      },
+
+      async getAccounts() {
+        if (!currentAccount && typeof window !== "undefined") {
+          const pk = localStorage.getItem(BURNER_STORAGE_KEY);
+          if (pk) {
+            currentAccount = privateKeyToAccount(pk as `0x${string}`);
+          }
+        }
+        return currentAccount ? [currentAccount.address as Address] : [];
+      },
+
+      async isAuthorized() {
+        if (typeof window === "undefined") return false;
+        return !!localStorage.getItem(BURNER_STORAGE_KEY);
+      },
+
+      async getChainId() {
+        return config.chains[0].id;
+      },
+
+      async switchChain({ chainId }) {
+        const chain = config.chains.find(x => x.id === chainId);
+        if (!chain) {
+          throw new Error(`Chain ${chainId} not configured`);
+        }
+        return chain;
+      },
+
+      async getProvider() {
+        // Burner wallet doesn't have an external provider
+        return null;
+      },
+
+      onAccountsChanged() {},
+      onChainChanged() {},
+      onDisconnect() {
+        if (typeof window !== "undefined") {
+          localStorage.removeItem(BURNER_STORAGE_KEY);
+          currentAccount = null;
+        }
+      },
+    };
+  });
+}
+
+/**
+ * Get the current burner wallet private key from storage
+ * @returns Private key or null if not found
+ */
+export function getBurnerPrivateKey(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(BURNER_STORAGE_KEY);
+}
+
+/**
+ * Delete the current burner wallet
+ */
+export function deleteBurnerWallet(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(BURNER_STORAGE_KEY);
+}
+
+/**
+ * Check if a burner wallet exists
+ */
+export function hasBurnerWallet(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!localStorage.getItem(BURNER_STORAGE_KEY);
+}

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -5,6 +5,7 @@ import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
 import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY, ScaffoldConfig } from "~~/scaffold.config";
 import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
+import { burnerWalletConnector } from "./burnerWallet";
 
 const { targetNetworks } = scaffoldConfig;
 
@@ -20,9 +21,22 @@ const wagmiAdapter = new WagmiAdapter({
   ssr: true,
 });
 
-// Create Wagmi config using the adapter's wagmi config
-export const wagmiConfig = wagmiAdapter.wagmiConfig as any || createConfig({
+// Add burner wallet connector in development mode
+const isDevelopment = process.env.NODE_ENV === "development";
+
+// Get all connectors
+const getAllConnectors = () => {
+  const baseConnectors = wagmiAdapter.wagmiConfig?.connectors || [];
+  if (isDevelopment) {
+    return [...baseConnectors, burnerWalletConnector()];
+  }
+  return baseConnectors;
+};
+
+// Create Wagmi config with burner wallet support
+export const wagmiConfig = createConfig({
   chains: enabledChains,
+  connectors: getAllConnectors() as any,
   ssr: true,
   client({ chain }) {
     let rpcFallbacks = [http()];


### PR DESCRIPTION
Add custom burner wallet connector compatible with Reown AppKit for quick testing and demos.

- Create burnerWallet.ts with Wagmi connector implementation
- Generate ephemeral private keys stored in localStorage
- Add BurnerWalletInfo component with security warnings
- Display private key export/delete functionality
- Enable only in development mode (NODE_ENV check)
- Add burner wallet icon asset

Features:
- Instant wallet creation without MetaMask
- Quick multi-account testing (multiple tabs)
- Demo presentations ready
- Clear security warnings displayed

Resolves #5

## Description

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #5_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
